### PR TITLE
Better toplevel callbacks and history system + bug fixes

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -117,7 +117,7 @@
 <!-- Clean console button -->
 <div class="fixed-action-btn hide-on-small-and-down" style="bottom: 15px; right: 15px;">
     <a class="btn-floating btn-small waves-effect waves-light zoom-button"
-       onclick="document.getElementById('output').innerHTML=''"><i
+       onclick="toplevelcallback.clear_toplevel()"><i
             class="material-icons">delete</i></a>
 </div>
 
@@ -126,7 +126,7 @@
     <a class="btn-floating btn-small waves-effect waves-light zoom-button" onclick="exec_all(editors[actual_editor()])"><i
             class="material-icons">play_arrow</i></a>
     <a class="btn-floating btn-small waves-effect waves-light zoom-button"
-       onclick="document.getElementById('output').innerHTML=''"><i
+       onclick="toplevelcallback.clear_toplevel()"><i
             class="material-icons">delete</i></a>
 </div>
 
@@ -185,7 +185,7 @@
                         class="material-icons">remove</i></a>
             </div>
 
-            <a class="waves-effect waves-light btn config-element" onclick="reset_ocaml();"><i
+            <a class="waves-effect waves-light btn config-element" onclick="toplevelcallback.reset_toplevel()"><i
                     class="material-icons right">refresh</i>Reset
                 OCaml Interpreter</a>
         </div>
@@ -243,7 +243,7 @@
 
     <!-- Toplevel flexbox -->
     <div id="box_2" class="box console-box">
-        <div id="toplevel-container" ondrop="dropHandler(event);" ondragover="dragOverHandler(event);">
+        <div id="toplevel-container">
             <pre id="output" height="auto"></pre>
             <div>
                 <div id="sharp" class="sharp"></div>
@@ -276,7 +276,7 @@
 
         // Set text zoom
         let r = document.querySelector(':root')
-        r.style.setProperty('--editor-font-size', (localStorage.getItem("betterocaml-text-editor") || "1.8em"));
+        r.style.setProperty('--editor-font-size', (localStorage.getItem("betterocaml-text-editor") || "1.2em"));
         r.style.setProperty('--toplevel-font-size', (localStorage.getItem("betterocaml-text-toplevel") || "1.2em"));
 
         // Service Worker

--- a/toplevel_build/dune
+++ b/toplevel_build/dune
@@ -68,12 +68,9 @@
          -I .
          --export %{dep:export.txt}
          --toplevel
-<<<<<<< Updated upstream
          --disable shortvar
          --disable genprim
-=======
          --opt 3
->>>>>>> Stashed changes
          +base/runtime.js
          +toplevel.js
          +dynlink.js

--- a/toplevel_build/dune
+++ b/toplevel_build/dune
@@ -68,8 +68,12 @@
          -I .
          --export %{dep:export.txt}
          --toplevel
+<<<<<<< Updated upstream
          --disable shortvar
          --disable genprim
+=======
+         --opt 3
+>>>>>>> Stashed changes
          +base/runtime.js
          +toplevel.js
          +dynlink.js


### PR DESCRIPTION
- Cleaner callbacks
- A command won't be added twice in a row in the history
- Fixed a bug where going all the way up the history would duplicate the oldest element
- Fixed a bug where empty lines would be added to the history by running an empty line
- Removed a deprecated "ondrop" causing errors when opening a file via drag and drop