### PR TITLE
🐛 fix error highlight location of js execute_callback

### DIFF
--- a/toplevel_build/toplevel.ml
+++ b/toplevel_build/toplevel.ml
@@ -355,6 +355,8 @@ let sanitize_command cmd =
     else cmd
 
 let execute_callback mode content =
+  let output = by_id "output" in
+  current_position := output##.childNodes##.length;
   let content' = sanitize_command content in
   match mode with
     |"internal" -> JsooTop.execute true ~pp_code:binsharp_ppf ~highlight_location bincaml_ppf content'
@@ -368,7 +370,6 @@ let run _ =
   let textbox : 'a Js.t = by_id_coerce "userinput" Dom_html.CoerceTo.textarea in
   let execute () =
     let content = Js.to_string textbox##.value##trim in
-    current_position := output##.childNodes##.length;
     History.push content;
     textbox##.value := Js.string "";
     execute_callback "toplevel" content;


### PR DESCRIPTION
The position is currently not updated when calling 'execute' from the js code.
This causes the highlight to be moved to the first line when code is executed from the editor.

Sample code:
```ocaml
let a = 5;;

let b = 3;;

a + b;;

let a = ;;
```